### PR TITLE
Scale geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# hexBlocker
+
+A GUI for generating a blockMeshDict for use with OpenFOAM.
+
+Current capabilities are: 
+
+* Creating and extruding blocks.
+* Exporting and importing blockMeshDicts.
+* Selecting boundary patches.
+* Setting the number of cells on each edge.
+* Moving vertices.
+* Rotating vertices.
+* Displaying geometries (STL files).
+* Bugs -- This is an alpha release and has plenty of them
+
+Copyright 2012, 2013;
+Author [Nicolas Edh](mailto:nicolas.edh@gmail.com), or 
+user "nsf" at www.cfd-online.com
+
+hexBlocker is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+hexBlocker is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with hexBlocker.  If not, see <http://www.gnu.org/licenses/>. 
+
+This program is not approved or endorsed by OpenCFD, the producer of the OpenFOAM(R) software and owner of the OpenFOAM(R) trade mark.

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -73,31 +73,12 @@ void HexBlocker::visibilityGeometry(bool mode)
 void HexBlocker::setModelScale(double scale)
 {
     convertToMeters = scale;
-    scaleGeometry();
 }
 
-void HexBlocker::setScaledGeometry(int option)
+void HexBlocker::scaleGeometry(double scale)
 {
-    scaledGeometry = option;
-}
-
-void HexBlocker::scaleGeometry()
-{
-    if(convertToMeters <= 0)    // sanity check
-    {
-        return;
-    }
-
-    double sf=appliedScaleFactor;
-    if(scaledGeometry == 0)     // restore scale
-    {
-        sf = 1.0/sf;
-        appliedScaleFactor = 1.0;
-    } else {                    // apply scale
-        sf = 1.0/convertToMeters;
-    }
     vtkSmartPointer<vtkTransform> transform = vtkSmartPointer<vtkTransform>::New();
-    transform->Scale(sf, sf, sf);
+    transform->Scale(scale, scale, scale);
     GeoActor->SetUserTransform(transform);
     this->render();
 }

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -24,6 +24,8 @@ License
 
 
 #include "HexBlocker.h"
+#include "ui_MainWindow.h"
+
 #include <vtkPolyData.h>
 #include <vtkSTLReader.h>
 #include <vtkSmartPointer.h>
@@ -32,15 +34,13 @@ License
 #include <vtkActor.h>
 #include <vtkRenderer.h>
 
+#include <QtGui>
+#include <QMainWindow>
+
 void HexBlocker::readGeometry(char* openFileName)
 {
     printf("reading: %s\n", openFileName);
 
-/* VTK 5.10 can't open ASCII STL files?
- * http://www.vtk.org/pipermail/vtkusers/2012-October/077163.html
- * http://www.paraview.org/Bug/view.php?id=14326
- * http://www.cfd-online.com/Forums/openfoam-paraview/124839-problems-ascii-stl.html
-*/
     vtkSmartPointer<vtkSTLReader> GeoReader = vtkSmartPointer<vtkSTLReader>::New();
     GeoReader->SetFileName(openFileName);
     GeoReader->Update();
@@ -69,3 +69,7 @@ void HexBlocker::visibilityGeometry(bool mode)
     GeoActor->SetVisibility(mode);
 }
 
+void HexBlocker::setModelScale(double scaleFactor)
+{
+    appliedScaleFactor = scaleFactor;
+}

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -94,7 +94,7 @@ void HexBlocker::scaleGeometry()
         sf = 1.0/sf;
         appliedScaleFactor = 1.0;
     } else {                    // apply scale
-        sf = convertToMeters;
+        sf = 1.0/convertToMeters;
     }
     vtkSmartPointer<vtkTransform> transform = vtkSmartPointer<vtkTransform>::New();
     transform->Scale(sf, sf, sf);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -33,6 +33,7 @@ License
 #include <vtkProperty.h>
 #include <vtkActor.h>
 #include <vtkRenderer.h>
+#include <vtkTransform.h>
 
 #include <QtGui>
 #include <QMainWindow>
@@ -69,7 +70,34 @@ void HexBlocker::visibilityGeometry(bool mode)
     GeoActor->SetVisibility(mode);
 }
 
-void HexBlocker::setModelScale(double scaleFactor)
+void HexBlocker::setModelScale(double scale)
 {
-    appliedScaleFactor = scaleFactor;
+    convertToMeters = scale;
+    scaleGeometry();
+}
+
+void HexBlocker::setScaledGeometry(int option)
+{
+    scaledGeometry = option;
+}
+
+void HexBlocker::scaleGeometry()
+{
+    if(convertToMeters <= 0)    // sanity check
+    {
+        return;
+    }
+
+    double sf=appliedScaleFactor;
+    if(scaledGeometry == 0)     // restore scale
+    {
+        sf = 1.0/sf;
+        appliedScaleFactor = 1.0;
+    } else {                    // apply scale
+        sf = convertToMeters;
+    }
+    vtkSmartPointer<vtkTransform> transform = vtkSmartPointer<vtkTransform>::New();
+    transform->Scale(sf, sf, sf);
+    GeoActor->SetUserTransform(transform);
+    this->render();
 }

--- a/src/HexBlocker.cpp
+++ b/src/HexBlocker.cpp
@@ -127,8 +127,6 @@ HexBlocker::HexBlocker()
 
     GeoActor = vtkSmartPointer<vtkActor>::New();
     convertToMeters = 1; // to be reset by user, or when reading a blockMeshDict file
-    appliedScaleFactor = 1;
-    scaledGeometry = 1;
 
 }
 
@@ -610,7 +608,6 @@ void HexBlocker::readBlockMeshDict(HexReader *reader)
     edges = reader->readEdges;
     patches = reader->readPatches;
     hexBCs = reader->readBCs;
-    appliedScaleFactor = reader->convertToMeters;
 
     vertData->SetPoints(vertices);
     vertices->Modified();

--- a/src/HexBlocker.cpp
+++ b/src/HexBlocker.cpp
@@ -126,6 +126,9 @@ HexBlocker::HexBlocker()
 //    widget->SetEnabled( 1 );
 
     GeoActor = vtkSmartPointer<vtkActor>::New();
+    convertToMeters = 1; // to be reset by user, or when reading a blockMeshDict file
+    appliedScaleFactor = 1;
+    scaledGeometry = 1;
 
 }
 
@@ -607,6 +610,7 @@ void HexBlocker::readBlockMeshDict(HexReader *reader)
     edges = reader->readEdges;
     patches = reader->readPatches;
     hexBCs = reader->readBCs;
+    appliedScaleFactor = reader->convertToMeters;
 
     vertData->SetPoints(vertices);
     vertices->Modified();

--- a/src/HexBlocker.h
+++ b/src/HexBlocker.h
@@ -176,10 +176,8 @@ public:
 
     //set model scale; related to convertToMeters in blockMeshDict
     void setModelScale(double scale);
-    void setScaledGeometry(int option);
-    void scaleGeometry();
+    void scaleGeometry(double scale);
     double convertToMeters;
-    double appliedScaleFactor;
     int scaledGeometry;
 
     //force a render

--- a/src/HexBlocker.h
+++ b/src/HexBlocker.h
@@ -174,6 +174,10 @@ public:
     void hideGeometry();
     void visibilityGeometry(bool mode);
 
+    //set model scale; related to convertToMeters in blockMeshDict
+    void setModelScale(double scaleFactor);
+    double appliedScaleFactor;
+
     //force a render
     void render();
 
@@ -197,7 +201,7 @@ public:
     vtkSmartPointer<vtkActor2D> vertLabelActor;
     vtkSmartPointer<vtkRenderer> renderer;
 
-    //to be removed, has info of arcs an such
+    //to be removed, has info of arcs and such
     QString edgesDict;
 
 private:

--- a/src/HexBlocker.h
+++ b/src/HexBlocker.h
@@ -175,8 +175,12 @@ public:
     void visibilityGeometry(bool mode);
 
     //set model scale; related to convertToMeters in blockMeshDict
-    void setModelScale(double scaleFactor);
+    void setModelScale(double scale);
+    void setScaledGeometry(int option);
+    void scaleGeometry();
+    double convertToMeters;
     double appliedScaleFactor;
+    int scaledGeometry;
 
     //force a render
     void render();

--- a/src/HexExporter.cpp
+++ b/src/HexExporter.cpp
@@ -36,7 +36,6 @@ HexExporter::HexExporter()
 HexExporter::HexExporter(HexBlocker *HB)
 {
     hexB = HB;
-    conv2meter=1.0;
 }
 
 void HexExporter::exporBlockMeshDict(QTextStream &out)
@@ -52,11 +51,7 @@ void HexExporter::exporBlockMeshDict(QTextStream &out)
         << "\t object \t blockMeshDict; " << endl
         << "}" << endl;
 
-    QString cnv2m;
-    cnv2m.sprintf("%g",conv2meter);
-    out << "convertToMeters " << cnv2m <<";" << endl;
-
-
+    out << "convertToMeters " << hexB->appliedScaleFactor <<";" << endl;
 
     hexB->exportVertices(out);
     out << endl;

--- a/src/HexExporter.cpp
+++ b/src/HexExporter.cpp
@@ -51,7 +51,7 @@ void HexExporter::exporBlockMeshDict(QTextStream &out)
         << "\t object \t blockMeshDict; " << endl
         << "}" << endl;
 
-    out << "convertToMeters " << hexB->appliedScaleFactor <<";" << endl;
+    out << "convertToMeters " << hexB->convertToMeters <<";" << endl;
 
     hexB->exportVertices(out);
     out << endl;

--- a/src/HexReader.cpp
+++ b/src/HexReader.cpp
@@ -47,6 +47,7 @@ HexReader::HexReader()
     readBlocks  = vtkSmartPointer<vtkCollection>::New();
     readEdges   = vtkSmartPointer<vtkCollection>::New();
     readBCs     = vtkSmartPointer<vtkCollection>::New();
+    convertToMeters = 1.0;
 }
 
 int HexReader::readBlockMeshDict(QTextStream *in)
@@ -54,6 +55,8 @@ int HexReader::readBlockMeshDict(QTextStream *in)
 
 
     fileContents = readFileContents(in);
+
+    getScale(); // Read convertToMeters value
 
     //Read vertices
     getVertices();
@@ -154,6 +157,21 @@ QString HexReader::getEntry(QString entry, QString container)
         returnEntry.append(QChar(contentsFromStart.at(i)));
     }
     return returnEntry.simplified();
+}
+
+
+bool HexReader::getScale()
+{
+    QString c2mString = getEntry(QString("convertToMeters"),fileContents);
+    QStringList c2mList = c2mString.split(QString(" "), QString::SkipEmptyParts);
+    bool ok;
+    convertToMeters = c2mList.at(1).toDouble(&ok);
+    if(!ok)
+    {
+        std::cout << "error reading convertToMeters: " << c2mString.toAscii().data() << std::endl;
+        return false;
+    }
+    return true;
 }
 
 
@@ -540,8 +558,8 @@ vtkIdType HexReader::findEge(vtkIdType vId0, vtkIdType vId1)
         {
             //check for correct order
             if(e->vertIds->GetId(0)!=vId0)
-                std::cout << "Warning edge (" << vId0 <<" " << vId1 <<")"
-                          << " was precribed with wrong order. This could cause problems." <<std::endl;
+                std::cout << "Warning: edge (" << vId0 <<" " << vId1 <<")"
+                          << " was prescribed with wrong order. This could cause problems." <<std::endl;
             return i;
         }
     }
@@ -551,6 +569,6 @@ vtkIdType HexReader::findEge(vtkIdType vId0, vtkIdType vId1)
 
 void HexReader::badEdgeEntry(QString edgeDict)
 {
-    std::cout << "warning can\'t parse edgeDict: " << edgeDict.toAscii().data()
+    std::cout << "Warning can\'t parse edgeDict: " << edgeDict.toAscii().data()
               << ". Note that some types are not yet supported." << std::endl;
 }

--- a/src/HexReader.h
+++ b/src/HexReader.h
@@ -63,6 +63,8 @@ public:
     vtkSmartPointer<vtkCollection> readEdges; //read edges
 
     QString edgesDict; //such as egdes or mergePairs
+    double convertToMeters;
+
 private:
     //FUNCTIONS
 
@@ -73,6 +75,8 @@ private:
     QString removeDoubleSlashes(QString line);
 
     void errorInGrading(vtkIdType hexNum, QString entry);
+
+    bool getScale();
 
     //fills vtkPoints with points from fileContents,
     //returns true if succesfull

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -595,16 +595,16 @@ void MainWindow::slotAboutDialog()
 {
     QString title("hexBlocker");
     QString text("\t hexBlocker\t\t version 0.1 \n"
-                 "A GUI for generating a blockMeshDict for use with OpenFOAM\n\n"
+                 "A GUI for generating a blockMeshDict for use with OpenFOAM.\n\n"
 
                  "Current capabilities are: \n\n"
                  "\t* Creating and extruding blocks.\n"
                  "\t* Exporting and importing blockMeshDicts.\n"
-                 "\t  Please note that only 2.1.x has been tested.\n"
                  "\t* Selecting boundary patches.\n"
                  "\t* Setting the number of cells on each edge.\n"
                  "\t* Moving vertices.\n"
                  "\t* Rotating vertices.\n"
+                 "\t* Displaying geometries (STL files).\n"
                  "\t* Bugs -- This is an alpha release and\n"
                  "\t  has plenty of them\n\n"
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -418,17 +418,6 @@ void MainWindow::slotSaveBlockMeshDict()
 
     QFile file(saveFileName);
 
-    QString title = tr("convertToMeters");
-    QString label = tr("Factor to convert to meters. If you modelled in mm this is 0.001.");
-    bool ok1;
-    double conv2meters = QInputDialog::getDouble(this,title,label,1.0,1e-255,1e255,6,&ok1);
-
-    if(!ok1)
-    {
-        this->ui->statusbar->showMessage("Cancelled",3000);
-        return;
-    }
-
     bool ok2 = file.open(QIODevice::WriteOnly | QIODevice::Text);
 
     if(!ok2)
@@ -439,7 +428,6 @@ void MainWindow::slotSaveBlockMeshDict()
     QTextStream out(&file);
 
     HexExporter * exporter = new HexExporter(hexBlocker);
-    exporter->conv2meter=conv2meters;
     exporter->exporBlockMeshDict(out);
 
     openFileName = saveFileName;
@@ -447,6 +435,22 @@ void MainWindow::slotSaveBlockMeshDict()
     file.close();
 }
 
+void MainWindow::slotSetScaleFactor()
+{
+    ui->statusbar->clearMessage();
+    QString title = tr("convertToMeters");
+    QString label = tr("Factor to convert to meters. If you modelled in mm this is 0.001.");
+
+    bool ok1;
+    double conv2meters = QInputDialog::getDouble(this,title,label,1.0,1e-255,1e255,6,&ok1);
+
+    if(!ok1)
+    {
+        this->ui->statusbar->showMessage("Cancelled",3000);
+        return;
+    }
+    hexBlocker->setModelScale(conv2meters);
+}
 
 void MainWindow::slotOpenBlockMeshDict()
 {
@@ -500,6 +504,7 @@ void MainWindow::slotReOpenBlockMeshDict()
     delete hexBlocker;
     hexBlocker = new HexBlocker();
     hexBlocker->renderer->SetBackground(.2, .3, .4);
+    hexBlocker->setModelScale(reader->convertToMeters);
 
     //reset pointers to hexBlocker in gui-classes
     toolbox->setHexBlockerPointer(hexBlocker);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -99,6 +99,7 @@ MainWindow::MainWindow()
     // Set up action signals and slots
     connect(this->ui->actionView_tool_bar,SIGNAL(triggered()),this,SLOT(slotViewToolBar()));
     connect(this->ui->actionView_tool_box,SIGNAL(triggered()),this,SLOT(slotViewToolBox()));
+    connect(this->ui->actionScaleFactor,SIGNAL(triggered()),this,SLOT(slotSetScaleFactor()));
     connect(this->ui->actionZoomOut, SIGNAL(triggered()), this, SLOT(slotZoomOut()));
     connect(this->ui->actionExit, SIGNAL(triggered()), this, SLOT(slotExit()));
     connect(this->ui->actionCreateHexBlock,SIGNAL(triggered()),this,SLOT(slotOpenCreateHexBlockDialog()));
@@ -442,7 +443,7 @@ void MainWindow::slotSetScaleFactor()
     QString label = tr("Factor to convert to meters. If you modelled in mm this is 0.001.");
 
     bool ok1;
-    double conv2meters = QInputDialog::getDouble(this,title,label,1.0,1e-255,1e255,6,&ok1);
+    double conv2meters = QInputDialog::getDouble(this,title,label,hexBlocker->appliedScaleFactor,1e-255,1e255,6,&ok1);
 
     if(!ok1)
     {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -569,6 +569,7 @@ void MainWindow::slotOpenGeometry()
     QByteArray ba = filename.toLatin1();
     char *openFileName = ba.data();
     hexBlocker->readGeometry(openFileName);
+    ui->statusbar->showMessage("Adjust the geometry size in \"Tools/Set geometry scale\"",10000);
 }
 
 void MainWindow::slotShowStatusText(QString text)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -451,6 +451,7 @@ void MainWindow::slotSetScaleFactor()
         return;
     }
     hexBlocker->setModelScale(conv2meters);
+    verticeEditor->displayScale(conv2meters);
 }
 
 void MainWindow::slotOpenBlockMeshDict()
@@ -526,6 +527,7 @@ void MainWindow::slotReOpenBlockMeshDict()
     toolbox->setBCsW->changeBCs(reader);
     verticeEditor->setHexBlocker(hexBlocker);
 //    verticeEditor->updateVertices();
+    verticeEditor->displayScale(hexBlocker->appliedScaleFactor);
 
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -99,7 +99,8 @@ MainWindow::MainWindow()
     // Set up action signals and slots
     connect(this->ui->actionView_tool_bar,SIGNAL(triggered()),this,SLOT(slotViewToolBar()));
     connect(this->ui->actionView_tool_box,SIGNAL(triggered()),this,SLOT(slotViewToolBox()));
-    connect(this->ui->actionScaleFactor,SIGNAL(triggered()),this,SLOT(slotSetScaleFactor()));
+    connect(this->ui->actionScaleMesh,SIGNAL(triggered()),this,SLOT(slotSetMeshScale()));
+    connect(this->ui->actionScaleGeometry,SIGNAL(triggered()),this,SLOT(slotSetGeometryScale()));
     connect(this->ui->actionZoomOut, SIGNAL(triggered()), this, SLOT(slotZoomOut()));
     connect(this->ui->actionExit, SIGNAL(triggered()), this, SLOT(slotExit()));
     connect(this->ui->actionCreateHexBlock,SIGNAL(triggered()),this,SLOT(slotOpenCreateHexBlockDialog()));
@@ -436,14 +437,14 @@ void MainWindow::slotSaveBlockMeshDict()
     file.close();
 }
 
-void MainWindow::slotSetScaleFactor()
+void MainWindow::slotSetMeshScale()
 {
     ui->statusbar->clearMessage();
     QString title = tr("convertToMeters");
     QString label = tr("Factor to convert to meters. If you modelled in mm this is 0.001.");
 
     bool ok1;
-    double conv2meters = QInputDialog::getDouble(this,title,label,hexBlocker->appliedScaleFactor,1e-255,1e255,6,&ok1);
+    double conv2meters = QInputDialog::getDouble(this,title,label,hexBlocker->convertToMeters,1e-255,1e255,6,&ok1);
 
     if(!ok1)
     {
@@ -452,6 +453,23 @@ void MainWindow::slotSetScaleFactor()
     }
     hexBlocker->setModelScale(conv2meters);
     verticeEditor->displayScale(conv2meters);
+}
+
+void MainWindow::slotSetGeometryScale()
+{
+    ui->statusbar->clearMessage();
+    QString title = tr("Scale geometry");
+    QString label = tr("Factor to scale the geometry, to match the mesh scale.");
+
+    bool ok1;
+    double conv2meters = QInputDialog::getDouble(this,title,label,1,1e-255,1e255,6,&ok1);
+
+    if(!ok1)
+    {
+        this->ui->statusbar->showMessage("Cancelled",3000);
+        return;
+    }
+    hexBlocker->scaleGeometry(conv2meters);
 }
 
 void MainWindow::slotOpenBlockMeshDict()
@@ -527,7 +545,7 @@ void MainWindow::slotReOpenBlockMeshDict()
     toolbox->setBCsW->changeBCs(reader);
     verticeEditor->setHexBlocker(hexBlocker);
 //    verticeEditor->updateVertices();
-    verticeEditor->displayScale(hexBlocker->appliedScaleFactor);
+    verticeEditor->displayScale(hexBlocker->convertToMeters);
 
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -121,6 +121,7 @@ public slots:
 
   void slotStartSelectPatchForEdgeSetType();
   void slotStartSelectPatchForEdgeSetTypeDone();
+  void slotSetScaleFactor();
 
 
 protected:

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -121,7 +121,8 @@ public slots:
 
   void slotStartSelectPatchForEdgeSetType();
   void slotStartSelectPatchForEdgeSetTypeDone();
-  void slotSetScaleFactor();
+  void slotSetMeshScale();
+  void slotSetGeometryScale();
 
 
 protected:

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -119,6 +119,8 @@
     <addaction name="actionEdgeVisibility"/>
     <addaction name="actionVertIDVisibility"/>
     <addaction name="actionGeometryVisibility"/>
+    <addaction name="separator"/>
+    <addaction name="actionScaleFactor"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuView"/>
@@ -344,6 +346,14 @@
    </property>
    <property name="text">
     <string>View tool box</string>
+   </property>
+  </action>
+  <action name="actionScaleFactor">
+   <property name="text">
+    <string>Set scale factor</string>
+   </property>
+   <property name="toolTip">
+    <string>(convertToMeters)</string>
    </property>
   </action>
   <action name="actionArbitraryTest">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -119,11 +119,17 @@
     <addaction name="actionEdgeVisibility"/>
     <addaction name="actionVertIDVisibility"/>
     <addaction name="actionGeometryVisibility"/>
-    <addaction name="separator"/>
-    <addaction name="actionScaleFactor"/>
+   </widget>
+   <widget class="QMenu" name="menuTools">
+    <property name="title">
+     <string>Tools</string>
+    </property>
+    <addaction name="actionScaleMesh"/>
+    <addaction name="actionScaleGeometry"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuView"/>
+   <addaction name="menuTools"/>
    <addaction name="menuAbout"/>
   </widget>
   <widget class="QToolBar" name="toolBar">
@@ -348,12 +354,17 @@
     <string>View tool box</string>
    </property>
   </action>
-  <action name="actionScaleFactor">
+  <action name="actionScaleMesh">
    <property name="text">
-    <string>Set scale factor</string>
+    <string>Set mesh scale</string>
    </property>
    <property name="toolTip">
     <string>(convertToMeters)</string>
+   </property>
+  </action>
+  <action name="actionScaleGeometry">
+   <property name="text">
+    <string>Set geometry scale</string>
    </property>
   </action>
   <action name="actionArbitraryTest">

--- a/src/VerticeEditorWidget.cpp
+++ b/src/VerticeEditorWidget.cpp
@@ -46,8 +46,7 @@ VerticeEditorWidget::VerticeEditorWidget(QWidget *parent) :
 
     connect(table,SIGNAL(pointEdited()),this,SLOT(slotPointChanged()));
 
-    connect(ui->scaleFactor,SIGNAL(returnPressed()),this,SLOT(slotSetScale()));
-    connect(ui->scaleGeometry,SIGNAL(stateChanged(int)),this,SLOT(slotSetScaleGeometry(int)));
+    connect(ui->scaleFactor,SIGNAL(editingFinished()),this,SLOT(slotSetScale()));
 
 }
 
@@ -88,8 +87,3 @@ void VerticeEditorWidget::displayScale(double scale)
     ui->scaleFactor->setText(QString::number(scale));
 }
 
-void VerticeEditorWidget::slotSetScaleGeometry(int state)   // 0=unchecked; 2=checked
-{
-    hexBlocker->scaledGeometry = state;
-    hexBlocker->scaleGeometry();
-}

--- a/src/VerticeEditorWidget.cpp
+++ b/src/VerticeEditorWidget.cpp
@@ -46,6 +46,8 @@ VerticeEditorWidget::VerticeEditorWidget(QWidget *parent) :
 
     connect(table,SIGNAL(pointEdited()),this,SLOT(slotPointChanged()));
 
+    connect(ui->scaleFactor,SIGNAL(returnPressed()),this,SLOT(slotSetScale()));
+
 }
 
 VerticeEditorWidget::~VerticeEditorWidget()
@@ -70,4 +72,17 @@ void VerticeEditorWidget::updateVertices()
 void VerticeEditorWidget::slotPointChanged()
 {
     hexBlocker->rescaleActors();
+}
+
+void VerticeEditorWidget::slotSetScale()
+{
+    double scale;
+    QString StrScale = ui->scaleFactor->text();
+    scale = StrScale.toDouble();
+    hexBlocker->setModelScale(scale);
+}
+
+void VerticeEditorWidget::displayScale(double scale)
+{
+    ui->scaleFactor->setText(QString::number(scale));
 }

--- a/src/VerticeEditorWidget.cpp
+++ b/src/VerticeEditorWidget.cpp
@@ -47,6 +47,7 @@ VerticeEditorWidget::VerticeEditorWidget(QWidget *parent) :
     connect(table,SIGNAL(pointEdited()),this,SLOT(slotPointChanged()));
 
     connect(ui->scaleFactor,SIGNAL(returnPressed()),this,SLOT(slotSetScale()));
+    connect(ui->scaleGeometry,SIGNAL(stateChanged(int)),this,SLOT(slotSetScaleGeometry(int)));
 
 }
 
@@ -85,4 +86,10 @@ void VerticeEditorWidget::slotSetScale()
 void VerticeEditorWidget::displayScale(double scale)
 {
     ui->scaleFactor->setText(QString::number(scale));
+}
+
+void VerticeEditorWidget::slotSetScaleGeometry(int state)   // 0=unchecked; 2=checked
+{
+    hexBlocker->scaledGeometry = state;
+    hexBlocker->scaleGeometry();
 }

--- a/src/VerticeEditorWidget.h
+++ b/src/VerticeEditorWidget.h
@@ -26,6 +26,7 @@ public slots:
     void slotPointChanged();
     void slotSetScale();
     void displayScale(double scale);
+    void slotSetScaleGeometry(int state);
 
 signals:
     void apply();

--- a/src/VerticeEditorWidget.h
+++ b/src/VerticeEditorWidget.h
@@ -26,7 +26,6 @@ public slots:
     void slotPointChanged();
     void slotSetScale();
     void displayScale(double scale);
-    void slotSetScaleGeometry(int state);
 
 signals:
     void apply();

--- a/src/VerticeEditorWidget.h
+++ b/src/VerticeEditorWidget.h
@@ -24,6 +24,8 @@ public:
 public slots:
     void updateVertices();
     void slotPointChanged();
+    void slotSetScale();
+    void displayScale(double scale);
 
 signals:
     void apply();

--- a/src/VerticeEditorWidget.ui
+++ b/src/VerticeEditorWidget.ui
@@ -15,6 +15,48 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout_3">
+
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <spacer name="horizontalSpacer1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="scaleFactor">
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>1</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="scaleGeo">
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>scale geometry</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+
     <item>
      <widget class="QFrame" name="frame">
       <property name="sizePolicy">

--- a/src/VerticeEditorWidget.ui
+++ b/src/VerticeEditorWidget.ui
@@ -32,25 +32,22 @@
        </spacer>
       </item>
       <item>
+       <widget class="QLabel" name="scaleLabel">
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Mesh scale</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLineEdit" name="scaleFactor">
         <property name="autoFillBackground">
          <bool>true</bool>
         </property>
         <property name="text">
          <string>1</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="scaleGeometry">
-        <property name="autoFillBackground">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>scale geometry</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/VerticeEditorWidget.ui
+++ b/src/VerticeEditorWidget.ui
@@ -42,7 +42,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="scaleGeo">
+       <widget class="QCheckBox" name="scaleGeometry">
         <property name="autoFillBackground">
          <bool>true</bool>
         </property>


### PR DESCRIPTION
Hi Nicolas,

I have just finished more changes. With them, now the value of convertToMeters is stored in HexBlocker class. It can be set both in "View/Set Scale" menu, or entering a value at the top of vertices list.

There is also a checkbox above the vertices list, which allows to scale the geometry. The applied scale is also stored, and it is recovered (set to 1) when the checkbox is un-checked. The logic behind it may be tricky, and surely it need more tests...

Thanks for your guidance with the code!
Leonardo Rosa